### PR TITLE
Fix: project prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Ignore all files in the "node_modules" directory
+node_modules/
+
+# Ignore all files with a ".min.js" extension
+**/*.min.js
+
+# Ignore specific files or directories
+dist/
+build/
+coverage/
+
+.husky
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 140
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "pnpm -r --parallel run lint",
     "dev": "pnpm -r --parallel run dev",
-    "build": "pnpm -r run build"
+    "build": "pnpm -r run build",
+    "format": "pnpm -r --parallel run format"
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,7 @@
   },
   "dependencies": {
     "dotenv": "16.4.7",
+    "prettier": "^3.4.2",
     "zod": "3.24.1"
   }
 }

--- a/packages/api/.prettierignore
+++ b/packages/api/.prettierignore
@@ -1,0 +1,14 @@
+# Ignore all files in the "node_modules" directory
+node_modules/
+
+# Ignore all files with a ".min.js" extension
+**/*.min.js
+
+# Ignore specific files or directories
+dist/
+build/
+coverage/
+
+.husky
+.next
+.vscode

--- a/packages/api/.prettierrc
+++ b/packages/api/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 140
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rimraf dist && tspc",
     "dev": "tsx watch src/app.ts",
-    "start": "node dist/app.js"
+    "start": "node dist/app.js",
+    "format": "prettier --write ."
   },
   "keywords": [],
   "author": "",

--- a/packages/web/.prettierignore
+++ b/packages/web/.prettierignore
@@ -1,0 +1,14 @@
+# Ignore all files in the "node_modules" directory
+node_modules/
+
+# Ignore all files with a ".min.js" extension
+**/*.min.js
+
+# Ignore specific files or directories
+dist/
+build/
+coverage/
+
+.husky
+.next
+.vscode

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
     "postcss": "8.4.38",
-    "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.9",
     "tailwindcss": "3.4.3",
     "typescript": "~5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
       zod:
         specifier: 3.24.1
         version: 3.24.1
@@ -208,9 +211,6 @@ importers:
       postcss:
         specifier: 8.4.38
         version: 8.4.38
-      prettier:
-        specifier: ^3.4.2
-        version: 3.4.2
       prettier-plugin-tailwindcss:
         specifier: ^0.6.9
         version: 0.6.9(@trivago/prettier-plugin-sort-imports@5.2.0(prettier@3.4.2))(prettier@3.4.2)


### PR DESCRIPTION


## Description
Fix prettier config to be used across whole project.

## Solution Adopted
Prettier was config to be used within web package, now it is config to be used from the root.

## How to Test
<!-- Describe the steps needed to test this PR, including any necessary setup and test cases. -->
Run `pnpm format` from the root.
