### PR TITLE
Fix cards modals

### DIFF
--- a/packages/web/src/features/main-section/step-types/cards/add-card-button.tsx
+++ b/packages/web/src/features/main-section/step-types/cards/add-card-button.tsx
@@ -1,13 +1,15 @@
-import { FormSelect } from '@/components/form/form-select';
 import { AttributeOption, strengthOptions } from '../utils';
 import { nonAssignedOption, useCardFormData } from './useCardFormData';
 import { ActionButton } from '@/components/action-button';
 import { FormModal } from '@/components/form/form-modal';
+import { FormMultiSelect } from '@/components/form/form-multi-select';
+import { FormSelect } from '@/components/form/form-select';
+import { FormTextArea } from '@/components/form/form-text-area';
 import { FormTextInput } from '@/components/form/form-text-input';
+import { useCardsStepContext } from '@/features/main-section/step-types/cards/context/use-cards-step-context';
 import { Attribute, CreateCardBody, createCardBodySchema, Keyword } from '@optimism-making-impact/schemas';
 import { Plus } from 'lucide-react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { FormMultiSelect } from '@/components/form/form-multi-select';
 
 interface AddCardModalProps {
   stepId: number;
@@ -62,6 +64,9 @@ interface FormFieldsProps {
 
 function FormFields(props: FormFieldsProps) {
   const { control } = useFormContext<CreateCardBody>();
+  const { step } = useCardsStepContext();
+
+  const smartListFilterLabel = step.smartListFilter?.title ?? '';
 
   return (
     <div className='flex flex-col gap-2'>
@@ -80,23 +85,25 @@ function FormFields(props: FormFieldsProps) {
           />
         )}
       />
-      <Controller
-        name='attributeId'
-        control={control}
-        render={({ field, fieldState }) => (
-          <FormSelect
-            error={fieldState.error?.message}
-            name={field.name}
-            label={'Smart List Filter'}
-            placeholder='Select Smart List Filter'
-            items={props.attributeOptions}
-            onValueChange={(value) => field.onChange(+value)}
-            disabled={props.attributeOptions.length === 0}
-            triggerClassName='capitalize'
-            itemClassName='capitalize'
-          />
-        )}
-      />
+      {smartListFilterLabel && (
+        <Controller
+          name='attributeId'
+          control={control}
+          render={({ field, fieldState }) => (
+            <FormSelect
+              error={fieldState.error?.message}
+              name={field.name}
+              label={smartListFilterLabel}
+              placeholder={`Select ${smartListFilterLabel}`}
+              items={props.attributeOptions}
+              onValueChange={(value) => field.onChange(+value)}
+              disabled={props.attributeOptions.length === 0}
+              triggerClassName='capitalize'
+              itemClassName='capitalize'
+            />
+          )}
+        />
+      )}
       <Controller
         name='title'
         control={control}
@@ -105,14 +112,16 @@ function FormFields(props: FormFieldsProps) {
       <Controller
         name='markdown'
         control={control}
-        render={({ field, fieldState }) => <FormTextInput label='Text' {...field} error={fieldState.error?.message} placeholder='Text' />}
+        render={({ field, fieldState }) => (
+          <FormTextArea label='Text' {...field} error={fieldState.error?.message} placeholder='Text' rows={5} />
+        )}
       />
       <Controller
         name='keywords'
         control={control}
         render={({ field }) => (
           <FormMultiSelect
-            label='Keywords connected'
+            label='Keywords'
             value={field.value}
             options={props.keywords}
             onChange={(value) => {

--- a/packages/web/src/features/main-section/step-types/cards/edit-card-button.tsx
+++ b/packages/web/src/features/main-section/step-types/cards/edit-card-button.tsx
@@ -3,8 +3,10 @@ import { nonAssignedOption, useCardFormData } from './useCardFormData';
 import { EditEntityModal } from '@/components/form/edit-entity-modal';
 import { FormMultiSelect } from '@/components/form/form-multi-select';
 import { FormSelect } from '@/components/form/form-select';
+import { FormTextArea } from '@/components/form/form-text-area';
 import { FormTextInput } from '@/components/form/form-text-input';
 import { EditIcon } from '@/components/icons/edit-icon';
+import { useCardsStepContext } from '@/features/main-section/step-types/cards/context/use-cards-step-context';
 import { CompleteCard } from '@/types/cards';
 import { Keyword } from '@/types/keywords';
 import { Attribute, UpdateCardBody, updateCardBodySchema } from '@optimism-making-impact/schemas';
@@ -85,6 +87,9 @@ interface FormFieldsProps {
 
 function FormFields({ attributeOptions, keywords }: FormFieldsProps) {
   const { control } = useFormContext<UpdateCardBody>();
+  const { step } = useCardsStepContext();
+
+  const smartListFilterLabel = step.smartListFilter?.title ?? '';
 
   return (
     <div className='flex flex-col gap-2'>
@@ -104,24 +109,26 @@ function FormFields({ attributeOptions, keywords }: FormFieldsProps) {
           />
         )}
       />
-      <Controller
-        name='attributeId'
-        control={control}
-        render={({ field, fieldState }) => (
-          <FormSelect
-            error={fieldState.error?.message}
-            name={field.name}
-            label={'Smart List Filter'}
-            placeholder='Select Smart List Filter'
-            items={attributeOptions}
-            value={field.value?.toString()}
-            onValueChange={(value) => field.onChange(+value)}
-            disabled={attributeOptions.length === 0}
-            triggerClassName='capitalize'
-            itemClassName='capitalize'
-          />
-        )}
-      />
+      {smartListFilterLabel && (
+        <Controller
+          name='attributeId'
+          control={control}
+          render={({ field, fieldState }) => (
+            <FormSelect
+              error={fieldState.error?.message}
+              name={field.name}
+              label={smartListFilterLabel}
+              placeholder='Select Smart List Filter'
+              items={attributeOptions}
+              value={field.value?.toString()}
+              onValueChange={(value) => field.onChange(+value)}
+              disabled={attributeOptions.length === 0}
+              triggerClassName='capitalize'
+              itemClassName='capitalize'
+            />
+          )}
+        />
+      )}
       <Controller
         name='title'
         control={control}
@@ -130,7 +137,9 @@ function FormFields({ attributeOptions, keywords }: FormFieldsProps) {
       <Controller
         name='markdown'
         control={control}
-        render={({ field, fieldState }) => <FormTextInput label='Text' {...field} error={fieldState.error?.message} placeholder='Text' />}
+        render={({ field, fieldState }) => (
+          <FormTextArea label='Text' {...field} error={fieldState.error?.message} placeholder='Text' rows={5} />
+        )}
       />
       <Controller
         name='keywords'
@@ -138,7 +147,7 @@ function FormFields({ attributeOptions, keywords }: FormFieldsProps) {
         render={({ field }) => (
           <FormMultiSelect
             name={field.name}
-            label='Keywords connected'
+            label='Keywords'
             value={field.value}
             options={keywords}
             onChange={(value) => {


### PR DESCRIPTION
## Ticket / Issue Tracking
<!-- Provide the ticket or issue number that this PR is addressing. -->
[OMI-191](https://wakeuplabs.atlassian.net/browse/OMI-191)

## Description
<!-- Provide a detailed description of the changes introduced by this PR. -->
This PR makes some changes in the modals to create/edit cards:
- Changes smart list filter select label from "Select Smart List Filter" to the actual name of the step list
- Doesnt render anymore this field if the step has no smart list
- Changes the label of the keywords field from "Keywords connected" to "Keywords"
- Changes text (markdown) field controller to a text area (defaults to 5 rows resizable) 

