### PR TITLE
Adjust card markdown components sizes

### DIFF
--- a/packages/web/src/features/main-section/step-types/cards/card.tsx
+++ b/packages/web/src/features/main-section/step-types/cards/card.tsx
@@ -128,10 +128,13 @@ function CardBody({ markdown, showMore, onViewMore }: CardBodyProps) {
   return (
     <div className={cn('relative h-[120px] overflow-hidden', { 'h-auto max-h-full': showMore })}>
       <div ref={containerRef} className={cn('max-h-[120px] overflow-hidden pr-2', { 'max-h-full': showMore })}>
-        <div className='prose-s prose flex w-full flex-1'>
+        <div className='prose prose-sm flex w-full flex-1'>
           <Markdown
             className='w-full break-words'
             components={{
+              h1: (props) => <h1 className='text-xl font-bold' {...props} />,
+              h2: (props) => <h2 className='text-lg font-bold' {...props} />,
+              h3: (props) => <p className='text-md font-bold' {...props} />,
               p: (props) => <p className='m-0 text-sm' {...props} />,
             }}
           >


### PR DESCRIPTION
## Ticket / Issue Tracking
<!-- Provide the ticket or issue number that this PR is addressing. -->
[OMI-227](https://wakeuplabs.atlassian.net/browse/OMI-227)

## Description

### Before
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/cd2afd26-1189-4d87-8251-2db7118badd0" />
<img width="1555" alt="image" src="https://github.com/user-attachments/assets/b2eaca91-11c8-4910-b29a-f65ba0dff41d" />

### After
<img width="1639" alt="image" src="https://github.com/user-attachments/assets/377d38a2-d1dd-498d-865d-81000c99e041" />
<img width="2063" alt="image" src="https://github.com/user-attachments/assets/9830bf4c-6a1c-4b9c-8b6d-e1a0c19f7409" />
