### PR TITLE
fix: update 'view more' button to appear correctly when card content …

### DIFF
--- a/packages/web/src/features/main-section/step-types/cards/card.tsx
+++ b/packages/web/src/features/main-section/step-types/cards/card.tsx
@@ -10,7 +10,7 @@ import { cn, getColor } from '@/lib/utils';
 import { CompleteCard } from '@/types/cards';
 import { CompleteKeyword } from '@/types/keywords';
 import { Attribute, CardStrength } from '@optimism-making-impact/schemas';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 
 interface CardProps {
@@ -111,17 +111,19 @@ function CardBody({ markdown, showMore, onViewMore }: CardBodyProps) {
   const [isOverflowing, setIsOverflowing] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const checkOverflow = () => {
+  const checkOverflow = useCallback(() => {
     const el = containerRef.current;
-    if (el)
-      setIsOverflowing(el.scrollHeight > el.clientHeight);
-  };
+    if (el) setIsOverflowing(el.scrollHeight > el.clientHeight);
+  }, []);
 
   useEffect(() => {
     checkOverflow();
+  }, [markdown]);
+
+  useEffect(() => {
     window.addEventListener('resize', checkOverflow);
     return () => window.removeEventListener('resize', checkOverflow);
-  }, []);
+  }, [checkOverflow]);
 
   return (
     <div className={cn('relative h-[120px] overflow-hidden', { 'h-auto max-h-full': showMore })}>


### PR DESCRIPTION
[OMI-229](https://wakeuplabs.atlassian.net/browse/OMI-229)

## Description

Fixed an issue where the "view more" button wasn't appearing when card content was edited after initial creation. Previously, the overflow detection only ran on initial render and window resize, but now it also runs whenever card content changes.

## Solution Adopted

- Added a dedicated `useEffect` hook that checks for content overflow when markdown content changes
- Used `useCallback` to properly handle function dependencies
- Improved code organization by separating resize event listener into its own effect

## How to Test

1. Create a card with content that doesn't overflow
2. Edit the card and add enough content to make it overflow
3. Verify that the "view more" button appears
4. Edit the card again to reduce content so it no longer overflows
5. Verify that the "view more" button disappears
