### PR TITLE
to prevent having to manage roundId -1 everywhere in the codebase; th…

### DIFF
--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -31,9 +31,9 @@ export function extractUniqueKeywordsFromCards(cards: CompleteCard[]): Keyword[]
 }
 
 export function getRoundName(roundId: number) {
-  if (roundId === 1) return "WakeUp Labs’ Proposed Experimentation Round – Milestone #3"
-  
-  return `Round ${roundId - 1}`;
+  if (roundId === 1) return 'WakeUp Labs’ Proposed Experimentation Round – Milestone #3';
+
+  return `Round ${roundId}`;
 }
 
 export function getColor(color: ExtendedColor): string {


### PR DESCRIPTION
…is PR just let the names to be WakeUp Labs' Proposed Experimentation, Round 2, Round 3, ...

## #Ticket / Issue Tracking
<!-- Provide the ticket or issue number that this PR is addressing. -->
[OMI-245](https://wakeuplabs.atlassian.net/browse/OMI-245)

## Description
The RoundId is displayed at Route URL and the displacement at name Round X -1  is making the UX confusing

## Solution Adopted
allow the naming of the actual Round ID


## How to Test
check the naming list this format
`
Round N,
...
Round 2,
WakeUp Labs' Proposed Experimentation
 `
