### PR TITLE
Bugfix: error creating rounds (prisma timeout)

### DIFF
--- a/packages/api/src/controllers/rounds-controller.ts
+++ b/packages/api/src/controllers/rounds-controller.ts
@@ -182,7 +182,7 @@ async function duplicateRound(originalRound: CompleteRound): Promise<number> {
       return newRound.id;
     },
     {
-      timeout: 30_000,
+      timeout: 30 * 1000,
     },
   );
 }

--- a/packages/api/src/controllers/rounds-controller.ts
+++ b/packages/api/src/controllers/rounds-controller.ts
@@ -169,17 +169,22 @@ type CompleteRound = Round & {
  * @returns The newly created round ID.
  */
 async function duplicateRound(originalRound: CompleteRound): Promise<number> {
-  return await prisma.$transaction(async (tx: Tx) => {
-    const newRound = await duplicateRoundRecord(tx, originalRound);
+  return await prisma.$transaction(
+    async (tx: Tx) => {
+      const newRound = await duplicateRoundRecord(tx, originalRound);
 
-    for (const category of originalRound.categories) {
-      const newCategory = await duplicateCategory(tx, category, newRound.id);
+      for (const category of originalRound.categories) {
+        const newCategory = await duplicateCategory(tx, category, newRound.id);
 
-      await duplicateSteps(tx, category.steps, newCategory);
-    }
+        await duplicateSteps(tx, category.steps, newCategory);
+      }
 
-    return newRound.id;
-  });
+      return newRound.id;
+    },
+    {
+      timeout: 30_000,
+    },
+  );
 }
 
 async function duplicateRoundRecord(tx: Tx, round: Round): Promise<Round> {


### PR DESCRIPTION


## Evidence

![image](https://github.com/user-attachments/assets/4c18660c-d4a5-4421-866d-67cfd14413b1)


## Description

This PR fixes a bug that occurs when creating a new round: occasionally, the process takes longer than 5 seconds, causing Prisma to prematurely close the transaction.

## Solution Adopted

A timeout of 30 seconds was set for the transaction to prevent it from being closed too early.


